### PR TITLE
Fix: Sending Attachments block

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "nest-pingbot",
-	"version": "1.0.1",
+	"version": "1.1.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "nest-pingbot",
-			"version": "1.0.1",
+			"version": "1.1.0",
 			"license": "MIT",
 			"dependencies": {
 				"@slack/web-api": "^7.9.0",
@@ -24,7 +24,7 @@
 				"@nestjs/schematics": "^11.0.2",
 				"@nestjs/testing": "^11.0.12",
 				"@types/jest": "^29.5.14",
-				"@types/node": "^22.13.10",
+				"@types/node": "^22.13.11",
 				"@typescript-eslint/eslint-plugin": "^8.27.0",
 				"@typescript-eslint/parser": "^8.27.0",
 				"eslint": "^9.22.0",
@@ -3051,9 +3051,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "22.13.10",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
-			"integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
+			"version": "22.13.11",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.11.tgz",
+			"integrity": "sha512-iEUCUJoU0i3VnrCmgoWCXttklWcvoCIx4jzcP22fioIVSdTmjgoEvmAO/QPw6TcS9k5FrNgn4w7q5lGOd1CT5g==",
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~6.20.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "nest-pingbot",
-	"version": "1.0.1",
+	"version": "1.1.0",
 	"description": "A NestJS messaging module for Slack and Discord notifications, built with a focus on simplicity and ease of use.",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
@@ -44,7 +44,7 @@
 		"@nestjs/schematics": "^11.0.2",
 		"@nestjs/testing": "^11.0.12",
 		"@types/jest": "^29.5.14",
-		"@types/node": "^22.13.10",
+		"@types/node": "^22.13.11",
 		"@typescript-eslint/eslint-plugin": "^8.27.0",
 		"@typescript-eslint/parser": "^8.27.0",
 		"eslint": "^9.22.0",

--- a/src/interfaces/message.ts
+++ b/src/interfaces/message.ts
@@ -1,4 +1,4 @@
-import { AnyBlock, Block, KnownBlock } from "@slack/web-api";
+import { AnyBlock, Block, KnownBlock, MessageAttachment } from "@slack/web-api";
 
 import { EmbedData } from "discord.js";
 
@@ -10,6 +10,8 @@ interface SlackMessageOptions {
 	blocks?: (KnownBlock | Block)[];
 
 	threadTs?: string;
+
+	attachments?: MessageAttachment[];
 
 	unfurlLinks?: boolean;
 	unfurlMedia?: boolean;
@@ -49,6 +51,7 @@ export {
 	AnyBlock,
 	KnownBlock,
 	EmbedData,
+	MessageAttachment,
 	// ? Message options
 	MessageOptions,
 	SlackMessageOptions,

--- a/src/service.ts
+++ b/src/service.ts
@@ -237,6 +237,11 @@ export class MessagingService implements OnModuleInit {
 				params.blocks = options.blocks;
 			}
 
+			if (options.attachments) {
+				// @ts-expect-error - Not sure why but the type is defined properly
+				params.attachments = options.attachments;
+			}
+
 			if (options.threadTs) {
 				params.thread_ts = options.threadTs;
 			}
@@ -260,6 +265,9 @@ export class MessagingService implements OnModuleInit {
 				text: options.text,
 				blocks: options.blocks,
 				channel: options.channel,
+				attachments: options.attachments,
+				unfurl_links: options.unfurlLinks,
+				unfurl_media: options.unfurlMedia,
 			});
 		} else {
 			throw new Error("No Slack client initialized");


### PR DESCRIPTION
# Description

This pull request fixes the issue where attachments were not being included in Slack messages when using the WebClient/Webhook. The `sendSlackMessage` function has been updated to ensure the `attachments` field is properly assigned to the WebClient's `postMessage` parameters.

## Related Issue(s)

Fixes #3

## Type of Change

- [x] Bug fix

## Checklist

- [x] I have tested my changes locally
- [x] I have added appropriate documentation or updated existing documentation
- [x] My code follows the project's coding conventions and style guidelines
- [x] All new and existing tests passed locally
- [x] I have reviewed my own code and ensured it is ready for review

## Additional Notes

This fix ensures that messages sent via the WebClient/Webhook will now properly include attachments if provided in the function parameters.

> [!IMPORTANT]  
> Ensure that this fix does not introduce unintended side effects by testing various Slack message configurations.